### PR TITLE
added configuration option for plantuml-format

### DIFF
--- a/src/main/java/org/jqassistant/contrib/plugin/asciidocreport/plantuml/ComponentDiagramReportPlugin.java
+++ b/src/main/java/org/jqassistant/contrib/plugin/asciidocreport/plantuml/ComponentDiagramReportPlugin.java
@@ -14,12 +14,15 @@ import com.buschmais.jqassistant.core.report.api.graph.SubGraphFactory;
 import com.buschmais.jqassistant.core.report.api.graph.model.SubGraph;
 
 public class ComponentDiagramReportPlugin implements ReportPlugin {
+    private static final String PROPERTY_FILE_FORMAT = "asciidoc.report.plantuml.format";
 
     private PlantUMLRenderer plantUMLRenderer;
 
     private ReportContext reportContext;
 
     private File directory;
+
+    private String fileFormat;
 
     @Override
     public void initialize() {
@@ -30,6 +33,7 @@ public class ComponentDiagramReportPlugin implements ReportPlugin {
     public void configure(ReportContext reportContext, Map<String, Object> properties) {
         this.reportContext = reportContext;
         directory = reportContext.getReportDirectory("plantuml");
+        fileFormat = (String) properties.get(PROPERTY_FILE_FORMAT);
     }
 
     @Override
@@ -37,7 +41,7 @@ public class ComponentDiagramReportPlugin implements ReportPlugin {
         SubGraphFactory subGraphFactory = new SubGraphFactory();
         SubGraph subGraph = subGraphFactory.createSubGraph(result);
         String componentDiagram = plantUMLRenderer.createComponentDiagram(subGraph);
-        File file = plantUMLRenderer.renderDiagram(componentDiagram, result.getRule(), directory);
+        File file = plantUMLRenderer.renderDiagram(componentDiagram, result.getRule(), directory, fileFormat);
         URL url;
         try {
             url = file.toURI().toURL();

--- a/src/test/java/org/jqassistant/contrib/plugin/asciidocreport/PlantUMLRendererTest.java
+++ b/src/test/java/org/jqassistant/contrib/plugin/asciidocreport/PlantUMLRendererTest.java
@@ -11,6 +11,7 @@ import com.buschmais.jqassistant.core.report.api.graph.model.Node;
 import com.buschmais.jqassistant.core.report.api.graph.model.Relationship;
 import com.buschmais.jqassistant.core.report.api.graph.model.SubGraph;
 
+import net.sourceforge.plantuml.FileFormat;
 import org.jqassistant.contrib.plugin.asciidocreport.plantuml.PlantUMLRenderer;
 import org.junit.Test;
 
@@ -63,19 +64,50 @@ public class PlantUMLRendererTest {
     }
 
     @Test
-    public void renderDiagram() {
+    public void renderDiagramAsSvg() {
+        File file = renderDiagram("svg", "svg");
+
+        assertThat(file.exists(), equalTo(true));
+    }
+
+    @Test
+    public void renderDiagramAsPng() {
+        File file = renderDiagram("png", "png");
+
+        assertThat(file.exists(), equalTo(true));
+    }
+
+    @Test
+    public void renderDiagramNoFormat() {
+        File file = renderDiagram(null, "svg");
+
+        assertThat(file.exists(), equalTo(true));
+    }
+
+    @Test
+    public void renderDiagramEmptyFormat() {
+        File file = renderDiagram("", "svg");
+
+        assertThat(file.exists(), equalTo(true));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void renderDiagramUnknownFormat() {
+        renderDiagram("notExisting", "");
+    }
+
+    private File renderDiagram(String format, String expectedFormat) {
         Concept concept = Concept.builder().id("test:plantuml").build();
         File directory = new File("target");
         directory.mkdirs();
-        File file = new File(directory,"test_plantuml.svg");
+        File file = new File(directory, "test_plantuml." + expectedFormat);
         if (file.exists()) {
             assertThat(file.delete(), equalTo(true));
         }
         String componentDiagram = plantUMLRenderer.createComponentDiagram(getSubGraph());
 
-        plantUMLRenderer.renderDiagram(componentDiagram, concept, directory);
-
-        assertThat(file.exists(), equalTo(true));
+        plantUMLRenderer.renderDiagram(componentDiagram, concept, directory, format);
+        return file;
     }
 
     private SubGraph getSubGraph() {


### PR DESCRIPTION
This is a useful feature if for some reason SVG is not supported. We use the HTML-Output, transform it and publish it to Confluence which can not display SVG-images out of the box.